### PR TITLE
Fix connection leaks.

### DIFF
--- a/app/util.js
+++ b/app/util.js
@@ -274,11 +274,12 @@ function pollUtilization(usageLink, limitLink, $scope, idx, lastLimitKey, $http,
 
               var usage_time = Date.parse(usage_stamp);
               var limit_time = Date.parse(limit_stamp);
+              // Need to normalize time by time zone offsets
               if (usage_time > limit_time) {
-                $scope.stamp = usage_stamp;
+                $scope.stamp = (new Date(usage_time)).toISOString();
                 console.log("usage stamp is greater than limit stamp");
               } else {
-                $scope.stamp = limit_stamp;
+                $scope.stamp = (new Date(limit_time)).toISOString();
               }
             })
       });

--- a/handlers.go
+++ b/handlers.go
@@ -57,12 +57,12 @@ func apiHandler(c *gin.Context) {
 		glog.Errorf("unable to GET %s - %v", metric_url, err)
 		return
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		glog.Errorf("GET %s responded with status code: %d", metric_url, resp.StatusCode)
 		return
 	}
 
-	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		glog.Errorf("unable to read response body from %s", metric_url)


### PR DESCRIPTION
I found kubedash's HTTP connection to heapster piles up. And the logs keep showing this message every 30 seconds:

```
E1229 06:17:01.612235       1 handlers.go:61] GET http://<heapster_service>/api/v1/model/metrics/memory-working?start=2015-12-29T13%3A55%3A00+08%3A00 responded with status code: 500
```

The corresponding heapster log for this message is:
```
E1229 06:11:31.956277       1 model_handlers.go:730] timestamp argument cannot be parsed: parsing time "2015-12-29T13:55:00 08:00" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "Z07:00"
```

After digging into code, the cause are

1. If heapster returns `500`, kubedash does not call `resp.Body.Close()`. So the HTTP persistent connection is not released to pooling.
2. The reason heapster returns `500` is because kubedash sends incorrect encoded query parameter, which the time zone offset `+08:00` is interpreted to `<space>08:00`. 

This PR fix this issue.