### PR TITLE
fix 404 for nav_logo

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -32,7 +32,7 @@
       <div class="container">
         <div class="row">
           <div class="col-xs-12">
-            <a href="/"><img src="http://kubernetes.io/img/desktop/nav_logo.svg" alt="Kubernetes by Google" id="logo-desktop" /></a>
+            <a href="/"><img src="http://kubernetes.io/images/nav_logo.svg" alt="Kubernetes by Google" id="logo-desktop" /></a>
             <nav>
               <a href="/" class="active" id="clusterbutton">
                 <div>


### PR DESCRIPTION
with the latest move of k8s docs, the logo is broken due to a
moved link. this pull request is to correct that missing link.
- fixed pages/index.html with the correct logo link
- `img/desktop/nav_logo.svg` -> `images/nav_logo.svg`
- fixes #53
